### PR TITLE
Remove file content from extract response

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This API extracts slide titles and notes from `.pptx` files. It is built with **
 
 ## Features
 
-- **POST `/extract`** – Accepts a JSON payload with `file_url` and `file_name`. The `file_url` should point to a downloadable `.pptx` file while `file_name` will be returned in the response. Returns the slide titles, speaker notes, and the original file content in base64.
+- **POST `/extract`** – Accepts a JSON payload with `file_url` and `file_name`. The `file_url` should point to a downloadable `.pptx` file while `file_name` will be returned in the response. Returns the slide titles and speaker notes for each slide.
 - Validation for supported file types and error handling for download/parse failures.
 - CORS enabled for testing purposes.
 - Suitable for running locally with `uvicorn` or in production with `gunicorn`.
@@ -37,4 +37,4 @@ curl -X POST http://localhost:8000/extract \
   -d '{"file_url": "https://example.com/sample.pptx", "file_name": "sample.pptx"}'
 ```
 
-The response echoes the provided `file_name` as `filename`, includes the base64 encoded PowerPoint data in `file_content`, the total slide count, and an array of slide data with titles and notes (if present).
+The response echoes the provided `file_name` as `filename` and returns the total slide count along with an array of slide data containing titles and notes when present.

--- a/extractor_api.py
+++ b/extractor_api.py
@@ -1,6 +1,5 @@
 import io
 import logging
-import base64
 from typing import List, Optional
 
 import requests
@@ -41,7 +40,6 @@ class SlideData(BaseModel):
 
 class ExtractResponse(BaseModel):
     filename: str
-    file_content: str
     slide_count: int
     slides: List[SlideData]
 
@@ -66,7 +64,6 @@ def extract_notes(request: ExtractRequest):
         raise HTTPException(status_code=422, detail="Only .pptx files are supported")
 
     pptx_bytes = io.BytesIO(response.content)
-    file_content = base64.b64encode(response.content).decode("utf-8")
     try:
         presentation = Presentation(pptx_bytes)
     except Exception as exc:  # pylint: disable=broad-except
@@ -96,7 +93,6 @@ def extract_notes(request: ExtractRequest):
     filename = request.file_name
     return ExtractResponse(
         filename=filename,
-        file_content=file_content,
         slide_count=len(slides_data),
         slides=slides_data,
     )

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,5 +1,4 @@
 import sys
-import base64
 from types import SimpleNamespace, ModuleType
 from unittest.mock import patch
 
@@ -80,7 +79,7 @@ def test_accepts_pptx_without_extension(mock_get):
     assert res.status_code == 200
     data = res.json()
     assert data["filename"] == "file.pptx"
-    assert data["file_content"] == base64.b64encode(b"content").decode("utf-8")
+    assert "file_content" not in data
     assert data["slide_count"] == 1
 
 


### PR DESCRIPTION
## Summary
- drop `file_content` from `ExtractResponse`
- update README to reflect the smaller response
- adjust tests for the new schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_683e29822a1483229b84b3638fbdebe6