### PR TITLE
Add configurable timeout for downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ pip install -r requirements.txt
 python extractor_api.py  # Runs with uvicorn on port 8000
 ```
 
+Set `REQUEST_TIMEOUT` to control the download timeout (in seconds). The default
+is `10` seconds.
+
 ## Deployment
 
 For Azure App Service, configure the startup command:

--- a/extractor_api.py
+++ b/extractor_api.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import base64
+import os
 from typing import List, Optional
 
 import requests
@@ -27,6 +28,10 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
 )
 
+# Allow the request timeout to be configured via an environment variable.
+# Defaults to 10 seconds if not provided.
+TIMEOUT = float(os.environ.get("REQUEST_TIMEOUT", "10"))
+
 
 class ExtractRequest(BaseModel):
     file_url: HttpUrl
@@ -52,7 +57,7 @@ def extract_notes(request: ExtractRequest):
     logger.info("Extraction requested for %s", url)
 
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=TIMEOUT)
         response.raise_for_status()
         logger.debug("Downloaded %d bytes", len(response.content))
     except requests.RequestException as exc:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -66,6 +66,7 @@ class FailingPresentation:
         raise ValueError("bad file")
 
 
+@patch("extractor_api.TIMEOUT", 5)
 @patch("extractor_api.requests.get")
 @patch("extractor_api.Presentation", DummyPresentation)
 def test_accepts_pptx_without_extension(mock_get):
@@ -78,12 +79,14 @@ def test_accepts_pptx_without_extension(mock_get):
         json={"file_url": "https://example.com/file", "file_name": "file.pptx"},
     )
     assert res.status_code == 200
+    mock_get.assert_called_once_with("https://example.com/file", timeout=5)
     data = res.json()
     assert data["filename"] == "file.pptx"
     assert data["file_content"] == base64.b64encode(b"content").decode("utf-8")
     assert data["slide_count"] == 1
 
 
+@patch("extractor_api.TIMEOUT", 5)
 @patch("extractor_api.requests.get")
 @patch("extractor_api.Presentation", FailingPresentation)
 def test_invalid_pptx_returns_422(mock_get):
@@ -95,3 +98,4 @@ def test_invalid_pptx_returns_422(mock_get):
     )
     assert res.status_code == 422
     assert res.json()["detail"] == "Only .pptx files are supported"
+    mock_get.assert_called_once_with("https://example.com/file", timeout=5)


### PR DESCRIPTION
## Summary
- make download timeout configurable via the `REQUEST_TIMEOUT` env var
- call `requests.get` with the timeout value
- document the variable in the README
- update tests to assert the timeout is used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_683e2e18eda0832295063711c5373000