### PR TITLE
Improve PPTX download error logging

### DIFF
--- a/extractor_api.py
+++ b/extractor_api.py
@@ -143,8 +143,14 @@ def combine_presentation(request: CombineRequest):
         pptx_bytes = download_file_from_graph(drive_id, pptx_id)
         pptx_name = get_item_name(drive_id, pptx_id)
     except Exception as exc:  # pylint: disable=broad-except
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status is not None:
+            logger.error("Failed to download PPTX from Graph: HTTP %s", status)
         logger.exception("Failed to download PPTX from Graph")
-        raise HTTPException(status_code=400, detail="Unable to download PPTX") from exc
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unable to download PPTX: {exc}",
+        ) from exc
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import extractor_api
+
+client = TestClient(extractor_api.app)
+
+
+class DummyHTTPError(Exception):
+    def __init__(self, status_code=500, message="boom"):
+        self.response = SimpleNamespace(status_code=status_code)
+        super().__init__(message)
+
+
+@patch("extractor_api.download_file_from_graph")
+def test_download_error_detail_contains_original_message(mock_download):
+    mock_download.side_effect = DummyHTTPError(404, "missing")
+    res = client.post(
+        "/combine",
+        json={"drive_id": "d", "folder_id": "f", "pptx_file_id": "p"},
+    )
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Unable to download PPTX: missing"
+    mock_download.assert_called_once_with("d", "p")
+


### PR DESCRIPTION
## Summary
- surface status code when failing to download PPTX
- include original exception message in download error details
- add unit test for the combine endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6840a4688784832285035f4347c3f056