### PR TITLE
Remove unused imports

### DIFF
--- a/extractor_api.py
+++ b/extractor_api.py
@@ -6,7 +6,6 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
-import glob
 import requests
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware

--- a/graph_utils.py
+++ b/graph_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable, Dict, List
+from typing import Iterable, Dict
 
 import requests
 


### PR DESCRIPTION
## Summary
- drop glob import from `extractor_api`
- drop unused typing import from `graph_utils`

## Testing
- `flake8 extractor_api.py graph_utils.py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6840a46dece48322b7b280b881316878