### PR TITLE
Add Microsoft Graph client credential auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ Set `REQUEST_TIMEOUT` to control the download timeout (in seconds). The default
 is `60` seconds.
 ## Environment Variables
 
-- `GRAPH_TOKEN` (required): OAuth bearer token for Microsoft Graph. Export it before running the server, e.g. `export GRAPH_TOKEN=XXXXX`.
+You can authenticate with Microsoft Graph using either a pre-generated OAuth token or client credentials.
+
+- `GRAPH_TOKEN` (optional): OAuth bearer token for Microsoft Graph.
+- `GRAPH_CLIENT_ID`, `GRAPH_TENANT_ID`, `GRAPH_CLIENT_SECRET` (optional): if set, the API obtains a token automatically using the client credentials flow.
 - `REQUEST_TIMEOUT` (optional): timeout in seconds when downloading files. Default is `60`.
 
 
@@ -52,7 +55,8 @@ The response echoes the provided `file_name` as `filename` and returns the total
 ### Example Combine Request
 
 ```bash
-GRAPH_TOKEN=YOUR_TOKEN curl -X POST http://localhost:8000/combine \
+# Ensure GRAPH_TOKEN or the client credential variables are set
+curl -X POST http://localhost:8000/combine \
   -H "Content-Type: application/json" \
   -d '{"drive_id": "<drive>", "folder_id": "<folder>", "pptx_file_id": "<id>"}'
 ```

--- a/graph_utils.py
+++ b/graph_utils.py
@@ -3,17 +3,57 @@
 from __future__ import annotations
 
 import os
-from typing import Iterable, Dict
+import time
+from typing import Iterable, Dict, Optional
 
 import requests
 
 GRAPH_BASE_URL = os.environ.get("GRAPH_BASE_URL", "https://graph.microsoft.com/v1.0")
 
+_cached_token: Optional[str] = None
+_token_expiry: float = 0.0
+
+
+def _get_token() -> str:
+    """Return a valid access token for Microsoft Graph."""
+    global _cached_token, _token_expiry
+
+    # Reuse token if it's still valid for at least 1 minute
+    if _cached_token and time.time() < _token_expiry - 60:
+        return _cached_token
+
+    env_token = os.getenv("GRAPH_TOKEN")
+    if env_token:
+        _cached_token = env_token
+        _token_expiry = time.time() + 3600
+        return _cached_token
+
+    client_id = os.getenv("GRAPH_CLIENT_ID")
+    tenant_id = os.getenv("GRAPH_TENANT_ID")
+    client_secret = os.getenv("GRAPH_CLIENT_SECRET")
+
+    if not all([client_id, tenant_id, client_secret]):
+        raise RuntimeError("Graph credentials not configured")
+
+    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    response = requests.post(
+        token_url,
+        data={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "scope": "https://graph.microsoft.com/.default",
+            "grant_type": "client_credentials",
+        },
+    )
+    response.raise_for_status()
+    data = response.json()
+    _cached_token = data["access_token"]
+    _token_expiry = time.time() + int(data.get("expires_in", 3600))
+    return _cached_token
+
 
 def _auth_headers() -> Dict[str, str]:
-    token = os.getenv("GRAPH_TOKEN")
-    if not token:
-        raise RuntimeError("GRAPH_TOKEN environment variable not set")
+    token = _get_token()
     return {"Authorization": f"Bearer {token}"}
 
 


### PR DESCRIPTION
## Summary
- implement token retrieval via client credentials in `graph_utils`
- document new credential variables in README

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6840b4af41ec8322bfa1e23ba39c28e4