### PR TITLE
Add httpx to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 python-pptx
 requests
 gunicorn
+httpx


### PR DESCRIPTION
## Summary
- update requirements to include httpx

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6840b9e9bd84832290ba4a9042c0fd6c