### PR TITLE
Improve ffprobe error handling

### DIFF
--- a/extractor_api.py
+++ b/extractor_api.py
@@ -198,7 +198,13 @@ def combine_presentation(request: CombineRequest):
                 result = subprocess.run(
                     cmd, capture_output=True, text=True, check=True
                 )
-            except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            except FileNotFoundError as exc:
+                logger.exception("ffprobe not found")
+                raise HTTPException(
+                    status_code=500,
+                    detail="ffprobe is not installed",
+                ) from exc
+            except subprocess.CalledProcessError as exc:
                 logger.exception("ffprobe failed")
                 raise HTTPException(
                     status_code=500,

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -116,3 +116,22 @@ def test_combine_ffprobe_error(mock_download, mock_get_name, mock_list, mock_run
     )
     assert res.status_code == 500
     assert res.json()["detail"] == "Audio metadata extraction failed"
+
+
+@patch("extractor_api.upload_file_to_graph")
+@patch("extractor_api.subprocess.run")
+@patch("extractor_api.list_folder_children")
+@patch("extractor_api.get_item_name")
+@patch("extractor_api.download_file_from_graph")
+def test_combine_ffprobe_missing(mock_download, mock_get_name, mock_list, mock_run, mock_upload):
+    mock_download.side_effect = lambda d, i: b"data"
+    mock_get_name.return_value = "slides.pptx"
+    mock_list.return_value = [{"id": "a1", "name": "slide_1.mp3"}]
+    mock_run.side_effect = _run_factory(["Slide-1.png"], ffprobe_error="file")
+
+    res = client.post(
+        "/combine",
+        json={"drive_id": "d", "folder_id": "f", "pptx_file_id": "p"},
+    )
+    assert res.status_code == 500
+    assert res.json()["detail"] == "ffprobe is not installed"


### PR DESCRIPTION
## Summary
- handle missing `ffprobe` binary in `/combine`
- add unit test for FileNotFoundError path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684213178b708322b776abf4506cda88