### PR TITLE
Add GHCR workflow and health endpoint

### DIFF
--- a/.github/workflows/azure-webapps-deploy.yml
+++ b/.github/workflows/azure-webapps-deploy.yml
@@ -29,4 +29,4 @@ jobs:
         uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
-          images: ${{ secrets.ACR_LOGIN_SERVER }}/pptx-extractor:${{ github.sha }}
+          images: ghcr.io/iius-rcox/pptx-extractor:latest

--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -1,0 +1,29 @@
+name: Build and push Docker image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/iius-rcox/pptx-extractor:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,11 @@ COPY . /app
 RUN pip install --no-cache-dir --upgrade pip && \
     if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; fi
 
+# Create non-root user
+RUN adduser --disabled-password --gecos "" appuser && chown -R appuser /app
+
+# Switch to non-root user
+USER appuser
+
 # Default command
 CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "extractor_api:app"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ For Azure App Service, configure the startup command:
 gunicorn -w 4 -k uvicorn.workers.UvicornWorker extractor_api:app
 ```
 
+### Using the container image
+
+An image is published to GitHub Container Registry as
+`ghcr.io/iius-rcox/pptx-extractor:latest`. To deploy on Azure App Service for
+Containers:
+
+1. Set the container image to `ghcr.io/iius-rcox/pptx-extractor:latest`.
+2. Leave the startup command empty – the container starts Gunicorn automatically.
+3. Set the application setting `WEBSITE_HEALTHCHECK_PATH=/health` so Azure can
+   monitor the API.
+
 ## Example Request
 
 ```bash

--- a/extractor_api.py
+++ b/extractor_api.py
@@ -31,6 +31,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Health check endpoint for Azure App Service
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Simple health check returning application status."""
+    return {"status": "ok"}
+
 logger = logging.getLogger("pptx_extractor")
 logging.basicConfig(
     level=logging.INFO,

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -85,6 +85,12 @@ def test_accepts_pptx_without_extension(mock_get):
     assert data["slide_count"] == 1
 
 
+def test_health_endpoint():
+    res = client.get("/health")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}
+
+
 @patch("extractor_api.TIMEOUT", 5)
 @patch("extractor_api.requests.get")
 @patch("extractor_api.Presentation", FailingPresentation)


### PR DESCRIPTION
## Summary
- create GitHub Actions workflow to build and push Docker image to GHCR
- change Azure deploy workflow to reference GHCR image
- run Docker container as non-root user
- add `/health` endpoint to support Azure health checks
- document container deployment and health check path
- test health endpoint in unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6842f2126778832289728ed6cbfeb843