### PR TITLE
Implement async HTTP operations and slide helpers

### DIFF
--- a/graph_utils.py
+++ b/graph_utils.py
@@ -6,15 +6,18 @@ import os
 import time
 from typing import Iterable, Dict, Optional
 
-import requests
+import httpx
 
 GRAPH_BASE_URL = os.environ.get("GRAPH_BASE_URL", "https://graph.microsoft.com/v1.0")
+
+# Shared HTTP client for Graph requests
+graph_client = httpx.AsyncClient()
 
 _cached_token: Optional[str] = None
 _token_expiry: float = 0.0
 
 
-def _get_token() -> str:
+async def _get_token() -> str:
     """Return a valid access token for Microsoft Graph."""
     global _cached_token, _token_expiry
 
@@ -36,7 +39,7 @@ def _get_token() -> str:
         raise RuntimeError("Graph credentials not configured")
 
     token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
-    response = requests.post(
+    response = await graph_client.post(
         token_url,
         data={
             "client_id": client_id,
@@ -52,42 +55,46 @@ def _get_token() -> str:
     return _cached_token
 
 
-def _auth_headers() -> Dict[str, str]:
-    token = _get_token()
+async def _auth_headers() -> Dict[str, str]:
+    token = await _get_token()
     return {"Authorization": f"Bearer {token}"}
 
 
-def download_file_from_graph(drive_id: str, item_id: str) -> bytes:
+async def download_file_from_graph(drive_id: str, item_id: str) -> bytes:
     """Return the file content for the given drive and item."""
     url = f"{GRAPH_BASE_URL}/drives/{drive_id}/items/{item_id}/content"
-    response = requests.get(url, headers=_auth_headers())
+    response = await graph_client.get(url, headers=await _auth_headers())
     response.raise_for_status()
     return response.content
 
 
-def upload_file_to_graph(drive_id: str, folder_id: str, filename: str, content: bytes) -> str:
+async def upload_file_to_graph(
+    drive_id: str, folder_id: str, filename: str, content: bytes
+) -> str:
     """Upload binary content and return the resulting file web URL."""
     url = f"{GRAPH_BASE_URL}/drives/{drive_id}/items/{folder_id}:/{filename}:/content"
-    response = requests.put(url, headers=_auth_headers(), data=content)
+    response = await graph_client.put(url, headers=await _auth_headers(), data=content)
     response.raise_for_status()
     data = response.json()
     # The Graph API returns the uploaded item metadata including a ``webUrl`` key
     return data.get("webUrl", "")
 
 
-def list_folder_children(drive_id: str, folder_id: str) -> Iterable[Dict[str, str]]:
+async def list_folder_children(
+    drive_id: str, folder_id: str
+) -> Iterable[Dict[str, str]]:
     """Return metadata for items within the folder."""
     url = f"{GRAPH_BASE_URL}/drives/{drive_id}/items/{folder_id}/children"
-    response = requests.get(url, headers=_auth_headers())
+    response = await graph_client.get(url, headers=await _auth_headers())
     response.raise_for_status()
     data = response.json()
     return data.get("value", [])
 
 
-def get_item_name(drive_id: str, item_id: str) -> str:
+async def get_item_name(drive_id: str, item_id: str) -> str:
     """Return the file name for the given item."""
     url = f"{GRAPH_BASE_URL}/drives/{drive_id}/items/{item_id}"
-    response = requests.get(url, headers=_auth_headers())
+    response = await graph_client.get(url, headers=await _auth_headers())
     response.raise_for_status()
     data = response.json()
     return data.get("name", "")

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,7 +1,6 @@
-import sys
 import subprocess
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -29,15 +28,18 @@ def _run_factory(images, raise_ffmpeg=False, ffprobe_error=None):
             extractor_api.Path(cmd[-1]).write_bytes(b"video")
             return SimpleNamespace()
         return SimpleNamespace()
+
     return _run
 
 
-@patch("extractor_api.upload_file_to_graph")
+@patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
 @patch("extractor_api.subprocess.run")
-@patch("extractor_api.list_folder_children")
-@patch("extractor_api.get_item_name")
-@patch("extractor_api.download_file_from_graph")
-def test_combine_success(mock_download, mock_get_name, mock_list, mock_run, mock_upload):
+@patch("extractor_api.list_folder_children", new_callable=AsyncMock)
+@patch("extractor_api.get_item_name", new_callable=AsyncMock)
+@patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
+def test_combine_success(
+    mock_download, mock_get_name, mock_list, mock_run, mock_upload
+):
     mock_download.side_effect = lambda d, i: b"data"
     mock_get_name.return_value = "slides.pptx"
     mock_list.return_value = [
@@ -58,9 +60,15 @@ def test_combine_success(mock_download, mock_get_name, mock_list, mock_run, mock
     mock_upload.assert_called_once()
 
 
-@patch("extractor_api.list_folder_children", return_value=[])
-@patch("extractor_api.get_item_name", return_value="slides.pptx")
-@patch("extractor_api.download_file_from_graph", return_value=b"data")
+@patch("extractor_api.list_folder_children", new_callable=AsyncMock, return_value=[])
+@patch(
+    "extractor_api.get_item_name", new_callable=AsyncMock, return_value="slides.pptx"
+)
+@patch(
+    "extractor_api.download_file_from_graph",
+    new_callable=AsyncMock,
+    return_value=b"data",
+)
 def test_combine_no_mp3(mock_download, mock_get_name, mock_list):
     res = client.post(
         "/combine",
@@ -70,8 +78,16 @@ def test_combine_no_mp3(mock_download, mock_get_name, mock_list):
     assert res.json()["detail"] == "No MP3 files found"
 
 
-@patch("extractor_api.get_item_name", side_effect=RuntimeError("fail"))
-@patch("extractor_api.download_file_from_graph", return_value=b"data")
+@patch(
+    "extractor_api.get_item_name",
+    new_callable=AsyncMock,
+    side_effect=RuntimeError("fail"),
+)
+@patch(
+    "extractor_api.download_file_from_graph",
+    new_callable=AsyncMock,
+    return_value=b"data",
+)
 def test_combine_graph_error(mock_download, mock_get_name):
     res = client.post(
         "/combine",
@@ -81,12 +97,14 @@ def test_combine_graph_error(mock_download, mock_get_name):
     assert res.json()["detail"] == "Unable to download PPTX"
 
 
-@patch("extractor_api.upload_file_to_graph")
+@patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
 @patch("extractor_api.subprocess.run")
-@patch("extractor_api.list_folder_children")
-@patch("extractor_api.get_item_name")
-@patch("extractor_api.download_file_from_graph")
-def test_combine_missing_binary(mock_download, mock_get_name, mock_list, mock_run, mock_upload):
+@patch("extractor_api.list_folder_children", new_callable=AsyncMock)
+@patch("extractor_api.get_item_name", new_callable=AsyncMock)
+@patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
+def test_combine_missing_binary(
+    mock_download, mock_get_name, mock_list, mock_run, mock_upload
+):
     mock_download.side_effect = lambda d, i: b"data"
     mock_get_name.return_value = "slides.pptx"
     mock_list.return_value = [{"id": "a1", "name": "slide_1.mp3"}]
@@ -99,12 +117,14 @@ def test_combine_missing_binary(mock_download, mock_get_name, mock_list, mock_ru
     assert res.status_code == 500
 
 
-@patch("extractor_api.upload_file_to_graph")
+@patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
 @patch("extractor_api.subprocess.run")
-@patch("extractor_api.list_folder_children")
-@patch("extractor_api.get_item_name")
-@patch("extractor_api.download_file_from_graph")
-def test_combine_ffprobe_error(mock_download, mock_get_name, mock_list, mock_run, mock_upload):
+@patch("extractor_api.list_folder_children", new_callable=AsyncMock)
+@patch("extractor_api.get_item_name", new_callable=AsyncMock)
+@patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
+def test_combine_ffprobe_error(
+    mock_download, mock_get_name, mock_list, mock_run, mock_upload
+):
     mock_download.side_effect = lambda d, i: b"data"
     mock_get_name.return_value = "slides.pptx"
     mock_list.return_value = [{"id": "a1", "name": "slide_1.mp3"}]
@@ -118,12 +138,14 @@ def test_combine_ffprobe_error(mock_download, mock_get_name, mock_list, mock_run
     assert res.json()["detail"] == "Audio metadata extraction failed"
 
 
-@patch("extractor_api.upload_file_to_graph")
+@patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
 @patch("extractor_api.subprocess.run")
-@patch("extractor_api.list_folder_children")
-@patch("extractor_api.get_item_name")
-@patch("extractor_api.download_file_from_graph")
-def test_combine_ffprobe_missing(mock_download, mock_get_name, mock_list, mock_run, mock_upload):
+@patch("extractor_api.list_folder_children", new_callable=AsyncMock)
+@patch("extractor_api.get_item_name", new_callable=AsyncMock)
+@patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
+def test_combine_ffprobe_missing(
+    mock_download, mock_get_name, mock_list, mock_run, mock_upload
+):
     mock_download.side_effect = lambda d, i: b"data"
     mock_get_name.return_value = "slides.pptx"
     mock_list.return_value = [{"id": "a1", "name": "slide_1.mp3"}]


### PR DESCRIPTION
## Summary
- refactor API to use async httpx client
- add helper functions for slides and ffprobe handling
- parallelize audio downloads and reuse a single HTTP client
- support configurable binary paths
- update tests for async functions

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6842f3ce858083228c0c336e4e248d26