### PR TITLE
Install ffmpeg and libreoffice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 
 # Install system dependencies
 RUN apt-get update && \
-    apt-get install -y ffmpeg && \
+    apt-get install -y ffmpeg libreoffice && \
     rm -rf /var/lib/apt/lists/*
 
 # Set work directory


### PR DESCRIPTION
## Summary
- install both ffmpeg and libreoffice in the container

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684351dc4e288322a119bff882d3949c