### PR TITLE
Add libreoffice missing test

### DIFF
--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -9,7 +9,7 @@ import extractor_api
 client = TestClient(extractor_api.app)
 
 
-def _run_factory(images, raise_ffmpeg=False, ffprobe_error=None):
+def _run_factory(images, raise_ffmpeg=False, ffprobe_error=None, raise_libreoffice=False):
     def _run(cmd, capture_output=False, text=False, check=False):
         if cmd[0] == "ffprobe":
             if ffprobe_error == "file":
@@ -18,6 +18,8 @@ def _run_factory(images, raise_ffmpeg=False, ffprobe_error=None):
                 raise subprocess.CalledProcessError(1, cmd)
             return SimpleNamespace(stdout="1.0")
         if cmd[0] == "libreoffice":
+            if raise_libreoffice:
+                raise FileNotFoundError("libreoffice")
             outdir = cmd[-1]
             for name in images:
                 (extractor_api.Path(outdir) / name).write_bytes(b"img")
@@ -157,3 +159,26 @@ def test_combine_ffprobe_missing(
     )
     assert res.status_code == 500
     assert res.json()["detail"] == "ffprobe is not installed"
+
+
+@patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
+@patch("extractor_api.subprocess.run")
+@patch("extractor_api.list_folder_children", new_callable=AsyncMock)
+@patch("extractor_api.get_item_name", new_callable=AsyncMock)
+@patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
+def test_combine_libreoffice_missing(
+    mock_download, mock_get_name, mock_list, mock_run, mock_upload
+):
+    mock_download.side_effect = lambda d, i: b"data"
+    mock_get_name.return_value = "slides.pptx"
+    mock_list.return_value = [{"id": "a1", "name": "slide_1.mp3"}]
+    mock_run.side_effect = _run_factory(
+        ["Slide-1.png"], raise_libreoffice=True
+    )
+
+    res = client.post(
+        "/combine",
+        json={"drive_id": "d", "folder_id": "f", "pptx_file_id": "p"},
+    )
+    assert res.status_code == 500
+    assert res.json()["detail"] == "PPTX conversion failed"


### PR DESCRIPTION
## Summary
- cover the libreoffice missing error path when combining slides

## Testing
- `pytest tests/test_combine.py::test_combine_libreoffice_missing -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684351f8dc208322a2ce785ad4e11801