### PR TITLE
Handle missing libreoffice binary

### DIFF
--- a/extractor_api.py
+++ b/extractor_api.py
@@ -279,6 +279,12 @@ async def combine_presentation(request: CombineRequest):
                 ],
                 check=True,
             )
+        except FileNotFoundError as exc:
+            logger.exception("libreoffice not found")
+            raise HTTPException(
+                status_code=500,
+                detail="libreoffice is not installed",
+            ) from exc
         except subprocess.CalledProcessError as exc:
             logger.exception("Slide image conversion failed")
             raise HTTPException(

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -181,4 +181,4 @@ def test_combine_libreoffice_missing(
         json={"drive_id": "d", "folder_id": "f", "pptx_file_id": "p"},
     )
     assert res.status_code == 500
-    assert res.json()["detail"] == "PPTX conversion failed"
+    assert res.json()["detail"] == "libreoffice is not installed"


### PR DESCRIPTION
## Summary
- raise a clear HTTP error if LibreOffice is missing
- update test expectation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684352c1cb048322b26a4fa73b84e094