### PR TITLE
Fix invalid URL type in extractor

### DIFF
--- a/extractor_api.py
+++ b/extractor_api.py
@@ -175,7 +175,7 @@ def build_crossfade_filter(durations: List[float]):
 
 @app.post("/extract", response_model=ExtractResponse)
 async def extract_notes(request: ExtractRequest):
-    url = request.file_url
+    url = str(request.file_url)
     logger.info("Extraction requested for %s", url)
 
     try:


### PR DESCRIPTION
## Summary
- fix `extract_notes` to convert pydantic `HttpUrl` to `str`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684355160734832281802e3f3c227f0a