### PR TITLE
Handle SharePoint redirect when downloading PPTX

### DIFF
--- a/graph_utils.py
+++ b/graph_utils.py
@@ -76,7 +76,9 @@ async def _auth_headers() -> Dict[str, str]:
 async def download_file_from_graph(drive_id: str, item_id: str) -> bytes:
     """Return the file content for the given drive and item."""
     url = f"{GRAPH_BASE_URL}/drives/{drive_id}/items/{item_id}/content"
-    response = await graph_client.get(url, headers=await _auth_headers())
+    response = await graph_client.get(
+        url, headers=await _auth_headers(), follow_redirects=True
+    )
     response.raise_for_status()
     return response.content
 

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,0 +1,20 @@
+import httpx
+import pytest
+from unittest.mock import AsyncMock, patch
+
+import graph_utils
+
+@pytest.mark.asyncio
+async def test_download_file_follows_redirects():
+    mock_client = AsyncMock()
+    mock_client.get.return_value = httpx.Response(status_code=200, content=b"data")
+    with patch.object(graph_utils, "graph_client", mock_client), \
+         patch("graph_utils._auth_headers", new=AsyncMock(return_value={"Authorization": "Bearer t"})):
+        result = await graph_utils.download_file_from_graph("d1", "i1")
+
+    mock_client.get.assert_awaited_once_with(
+        "https://graph.microsoft.com/v1.0/drives/d1/items/i1/content",
+        headers={"Authorization": "Bearer t"},
+        follow_redirects=True,
+    )
+    assert result == b"data"


### PR DESCRIPTION
## Summary
- follow redirects for Microsoft Graph download
- add regression test for following redirects

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684359afc3bc8322b8a9b89847b53699