### PR TITLE
Handle connection pool exhaustion in Graph client

### DIFF
--- a/graph_utils.py
+++ b/graph_utils.py
@@ -15,9 +15,16 @@ graph_client: Optional[httpx.AsyncClient] = None
 
 
 async def startup_graph_client() -> None:
-    """Create the HTTP client used for Graph requests."""
+    """Create the HTTP client used for Graph requests.
+
+    The default connection pool limit of ``httpx.AsyncClient`` is ``100``. When
+    downloading many audio files concurrently this limit can be exceeded which
+    results in ``PoolTimeout`` errors. To avoid this we create the client with
+    an unlimited connection pool.
+    """
     global graph_client
-    graph_client = httpx.AsyncClient()
+    limits = httpx.Limits(max_keepalive_connections=None, max_connections=None)
+    graph_client = httpx.AsyncClient(limits=limits)
 
 
 async def close_graph_client() -> None:


### PR DESCRIPTION
## Summary
- avoid PoolTimeout errors when downloading many files concurrently by creating Graph client with unlimited connection pool

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_68442001dd308322b80732fcbda859b9