### PR TITLE
Document binary path env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ You can authenticate with Microsoft Graph using either a pre-generated OAuth tok
 - `GRAPH_TOKEN` (optional): OAuth bearer token for Microsoft Graph.
 - `GRAPH_CLIENT_ID`, `GRAPH_TENANT_ID`, `GRAPH_CLIENT_SECRET` (optional): if set, the API obtains a token automatically using the client credentials flow.
 - `REQUEST_TIMEOUT` (optional): timeout in seconds when downloading files. Default is `60`.
+- `FFPROBE_BIN`, `FFMPEG_BIN`, `LIBREOFFICE_BIN` (optional): paths to the
+  `ffprobe`, `ffmpeg` and `libreoffice` executables. These override the
+  system defaults used by the `/combine` endpoint.
 
 
 ## Deployment


### PR DESCRIPTION
## Summary
- document `FFPROBE_BIN`, `FFMPEG_BIN`, and `LIBREOFFICE_BIN` environment variables in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi/httpx)*

------
https://chatgpt.com/codex/tasks/task_b_6846f31544cc83228cf1d241cf14f661