### PR TITLE
Improve resilience for slow networks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN adduser --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
 # Default command
-CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "extractor_api:app"]
+CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "-c", "gunicorn.conf.py", "extractor_api:app"]

--- a/README.md
+++ b/README.md
@@ -23,15 +23,19 @@ pip install -r requirements.txt
 python extractor_api.py  # Runs with uvicorn on port 8000
 ```
 
-Set `REQUEST_TIMEOUT` to control the download timeout (in seconds). The default
-is `60` seconds.
+Set `REQUEST_TIMEOUT` to control the read timeout (in seconds) when downloading files (default `60`).
+Use `CONNECT_TIMEOUT` to limit how long to wait for an initial connection (default `10`).
+`DOWNLOAD_CONCURRENCY` determines how many files are fetched simultaneously (default `5`).
 ## Environment Variables
 
 You can authenticate with Microsoft Graph using either a pre-generated OAuth token or client credentials.
 
 - `GRAPH_TOKEN` (optional): OAuth bearer token for Microsoft Graph.
 - `GRAPH_CLIENT_ID`, `GRAPH_TENANT_ID`, `GRAPH_CLIENT_SECRET` (optional): if set, the API obtains a token automatically using the client credentials flow.
-- `REQUEST_TIMEOUT` (optional): timeout in seconds when downloading files. Default is `60`.
+- `REQUEST_TIMEOUT` (optional): read timeout in seconds for downloads. Default is `60`.
+- `CONNECT_TIMEOUT` (optional): connection timeout in seconds. Default is `10`.
+- `DOWNLOAD_CONCURRENCY` (optional): number of files downloaded concurrently. Default is `5`.
+- `GUNICORN_TIMEOUT` (optional): worker timeout for Gunicorn in seconds. Default is `300`.
 - `FFPROBE_BIN`, `FFMPEG_BIN`, `LIBREOFFICE_BIN` (optional): paths to the
   `ffprobe`, `ffmpeg` and `libreoffice` executables. These override the
   system defaults used by the `/combine` endpoint.
@@ -39,10 +43,10 @@ You can authenticate with Microsoft Graph using either a pre-generated OAuth tok
 
 ## Deployment
 
-For Azure App Service, configure the startup command:
+For Azure App Service, configure the startup command with a longer timeout:
 
 ```bash
-gunicorn -w 4 -k uvicorn.workers.UvicornWorker extractor_api:app
+gunicorn -w 4 -k uvicorn.workers.UvicornWorker -c gunicorn.conf.py extractor_api:app
 ```
 
 ### Using the container image
@@ -52,7 +56,7 @@ An image is published to GitHub Container Registry as
 Containers:
 
 1. Set the container image to `ghcr.io/iius-rcox/pptx-extractor:latest`.
-2. Leave the startup command empty – the container starts Gunicorn automatically.
+2. Leave the startup command empty – the container starts Gunicorn automatically using `gunicorn.conf.py`.
 3. Set the application setting `WEBSITE_HEALTHCHECK_PATH=/health` so Azure can
    monitor the API.
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,8 @@
+import os
+
+# Increase worker timeout for long running operations
+# Default is 30 seconds which is too short for large downloads/conversions
+
+timeout = int(os.getenv("GUNICORN_TIMEOUT", "300"))
+# Allow some time for graceful shutdowns
+graceful_timeout = 30

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -10,7 +10,7 @@ client = TestClient(extractor_api.app)
 
 
 def _run_factory(images, raise_ffmpeg=False, ffprobe_error=None, raise_libreoffice=False):
-    def _run(cmd, capture_output=False, text=False, check=False):
+    async def _run(cmd):
         if cmd[0] == "ffprobe":
             if ffprobe_error == "file":
                 raise FileNotFoundError("ffprobe")
@@ -35,7 +35,7 @@ def _run_factory(images, raise_ffmpeg=False, ffprobe_error=None, raise_libreoffi
 
 
 @patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
-@patch("extractor_api.subprocess.run")
+@patch("extractor_api.run_cmd", new_callable=AsyncMock)
 @patch("extractor_api.list_folder_children", new_callable=AsyncMock)
 @patch("extractor_api.get_item_name", new_callable=AsyncMock)
 @patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
@@ -63,7 +63,7 @@ def test_combine_success(
 
 
 @patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
-@patch("extractor_api.subprocess.run")
+@patch("extractor_api.run_cmd", new_callable=AsyncMock)
 @patch("extractor_api.list_folder_children", new_callable=AsyncMock)
 @patch("extractor_api.get_item_name", new_callable=AsyncMock)
 @patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
@@ -127,7 +127,7 @@ def test_combine_graph_error(mock_download, mock_get_name):
 
 
 @patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
-@patch("extractor_api.subprocess.run")
+@patch("extractor_api.run_cmd", new_callable=AsyncMock)
 @patch("extractor_api.list_folder_children", new_callable=AsyncMock)
 @patch("extractor_api.get_item_name", new_callable=AsyncMock)
 @patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
@@ -148,7 +148,7 @@ def test_combine_missing_binary(
 
 
 @patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
-@patch("extractor_api.subprocess.run")
+@patch("extractor_api.run_cmd", new_callable=AsyncMock)
 @patch("extractor_api.list_folder_children", new_callable=AsyncMock)
 @patch("extractor_api.get_item_name", new_callable=AsyncMock)
 @patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
@@ -169,7 +169,7 @@ def test_combine_ffprobe_error(
 
 
 @patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
-@patch("extractor_api.subprocess.run")
+@patch("extractor_api.run_cmd", new_callable=AsyncMock)
 @patch("extractor_api.list_folder_children", new_callable=AsyncMock)
 @patch("extractor_api.get_item_name", new_callable=AsyncMock)
 @patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)
@@ -190,7 +190,7 @@ def test_combine_ffprobe_missing(
 
 
 @patch("extractor_api.upload_file_to_graph", new_callable=AsyncMock)
-@patch("extractor_api.subprocess.run")
+@patch("extractor_api.run_cmd", new_callable=AsyncMock)
 @patch("extractor_api.list_folder_children", new_callable=AsyncMock)
 @patch("extractor_api.get_item_name", new_callable=AsyncMock)
 @patch("extractor_api.download_file_from_graph", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary
- increase gunicorn timeout via config file
- tune httpx client timeouts for slow networks
- add async run_cmd helper for subprocesses
- limit download concurrency and wrap downloads with timeout
- configure Graph API client with explicit timeout and retry downloads
- document environment variables and updated startup command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_68474b8941b88322a3c441bf1ad29af1