### PR TITLE
Fix container port for Azure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,8 @@ RUN adduser --disabled-password --gecos "" appuser && chown -R appuser /app
 # Switch to non-root user
 USER appuser
 
+# Expose the HTTP port used by the application
+EXPOSE 80
+
 # Default command
-CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "-c", "gunicorn.conf.py", "extractor_api:app"]
+CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "-b", "0.0.0.0:80", "-c", "gunicorn.conf.py", "extractor_api:app"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Containers:
 2. Leave the startup command empty – the container starts Gunicorn automatically using `gunicorn.conf.py`.
 3. Set the application setting `WEBSITE_HEALTHCHECK_PATH=/health` so Azure can
    monitor the API.
+4. The container listens on port **80**; ensure any App Service settings or networking rules allow traffic on this port.
 
 ## Example Request
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -6,3 +6,6 @@ import os
 timeout = int(os.getenv("GUNICORN_TIMEOUT", "300"))
 # Allow some time for graceful shutdowns
 graceful_timeout = 30
+
+# Bind to the port expected by Azure App Service
+bind = "0.0.0.0:80"


### PR DESCRIPTION
## Summary
- expose port 80 in Dockerfile
- bind gunicorn to 0.0.0.0:80
- document port 80 requirement

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_68475281d8488322be8b9fa370255675