### PR TITLE
Improve run_cmd error handling

### DIFF
--- a/extractor_api.py
+++ b/extractor_api.py
@@ -172,9 +172,16 @@ def get_audio_duration(path: Path) -> float:
 
 async def run_cmd(cmd: List[str]) -> None:
     """Run an external command asynchronously and raise on failure."""
-    proc = await asyncio.create_subprocess_exec(*cmd)
-    if await proc.wait() != 0:
-        raise subprocess.CalledProcessError(proc.returncode, cmd)
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(
+            proc.returncode, cmd, output=stdout, stderr=stderr
+        )
 
 
 def build_ffmpeg_inputs(images: List[Path], audios: List[Path], durations: List[float]):

--- a/tests/test_run_cmd.py
+++ b/tests/test_run_cmd.py
@@ -1,0 +1,21 @@
+import subprocess
+
+import pytest
+
+import extractor_api
+
+
+@pytest.mark.asyncio
+async def test_run_cmd_raises_with_output():
+    cmd = [
+        "python",
+        "-c",
+        "import sys; print('err', file=sys.stderr); sys.exit(1)",
+    ]
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        await extractor_api.run_cmd(cmd)
+
+    assert exc.value.returncode == 1
+    assert exc.value.cmd == cmd
+    assert exc.value.output == b""
+    assert exc.value.stderr == b"err\n"


### PR DESCRIPTION
## Summary
- capture stdout/stderr from helper function `run_cmd`
- test that failing commands raise `CalledProcessError` with captured output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_68475f71f0848322a309909e12efd370