### PR TITLE
Fix httpx timeout config

### DIFF
--- a/graph_utils.py
+++ b/graph_utils.py
@@ -27,7 +27,12 @@ async def startup_graph_client() -> None:
     """
     global graph_client
     limits = httpx.Limits(max_keepalive_connections=None, max_connections=None)
-    timeout = httpx.Timeout(connect=CONNECT_TIMEOUT, read=REQUEST_TIMEOUT)
+    timeout = httpx.Timeout(
+        connect=CONNECT_TIMEOUT,
+        read=REQUEST_TIMEOUT,
+        write=REQUEST_TIMEOUT,
+        pool=CONNECT_TIMEOUT,
+    )
     graph_client = httpx.AsyncClient(limits=limits, timeout=timeout)
 
 


### PR DESCRIPTION
## Summary
- ensure all timeout parameters are supplied when starting the Microsoft Graph client

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_68476048fe308322bd1b992d54b81e7f