### PR TITLE
Fix httpx timeout misconfiguration

### DIFF
--- a/extractor_api.py
+++ b/extractor_api.py
@@ -59,12 +59,8 @@ DOWNLOAD_CONCURRENCY = int(os.environ.get("DOWNLOAD_CONCURRENCY", "5"))
 # httpx requires all timeout parameters be specified when using custom values.
 # Create a reusable configuration object shared by the client and per-request
 # calls so that connection and read timeouts are explicit.
-HTTPX_TIMEOUT = httpx.Timeout(
-    connect=CONNECT_TIMEOUT,
-    read=TIMEOUT,
-    write=TIMEOUT,
-    pool=CONNECT_TIMEOUT,
-)
+# Use a single timeout value for all operations to avoid misconfiguration
+HTTPX_TIMEOUT = httpx.Timeout(TIMEOUT)
 
 # Reusable HTTP client for outbound requests - created at startup
 http_client: httpx.AsyncClient | None = None

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -35,10 +35,7 @@ class FailingPresentation:
         raise ValueError("bad file")
 
 
-@patch(
-    "extractor_api.HTTPX_TIMEOUT",
-    httpx.Timeout(connect=10, read=5, write=5, pool=10),
-)
+@patch("extractor_api.HTTPX_TIMEOUT", httpx.Timeout(5))
 @patch("extractor_api.TIMEOUT", 5)
 @patch("extractor_api.http_client.get", new_callable=AsyncMock)
 @patch("extractor_api.Presentation", DummyPresentation)
@@ -69,10 +66,7 @@ def test_health_endpoint():
     assert res.json() == {"status": "ok"}
 
 
-@patch(
-    "extractor_api.HTTPX_TIMEOUT",
-    httpx.Timeout(connect=10, read=5, write=5, pool=10),
-)
+@patch("extractor_api.HTTPX_TIMEOUT", httpx.Timeout(5))
 @patch("extractor_api.TIMEOUT", 5)
 @patch("extractor_api.http_client.get", new_callable=AsyncMock)
 @patch("extractor_api.Presentation", FailingPresentation)
@@ -91,10 +85,7 @@ def test_invalid_pptx_returns_422(mock_presentation, mock_get):
         follow_redirects=True,
     )
 
-@patch(
-    "extractor_api.HTTPX_TIMEOUT",
-    httpx.Timeout(connect=10, read=5, write=5, pool=10),
-)
+@patch("extractor_api.HTTPX_TIMEOUT", httpx.Timeout(5))
 @patch("extractor_api.TIMEOUT", 5)
 @patch("extractor_api.http_client.get", new_callable=AsyncMock)
 def test_download_http_error(mock_get):
@@ -111,10 +102,7 @@ def test_download_http_error(mock_get):
     )
 
 
-@patch(
-    "extractor_api.HTTPX_TIMEOUT",
-    httpx.Timeout(connect=10, read=5, write=5, pool=10),
-)
+@patch("extractor_api.HTTPX_TIMEOUT", httpx.Timeout(5))
 @patch("extractor_api.TIMEOUT", 5)
 @patch("extractor_api.http_client.get", new_callable=AsyncMock)
 def test_download_request_error(mock_get):


### PR DESCRIPTION
## Summary
- use single timeout value in FastAPI app
- update unit tests for new timeout style

## Testing
- `pip install -r requirements.txt` *(fails: Could not find fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684767df80188322a66eb1b24b53a0f8