### PR TITLE
Add HTML-to-PDF using WeasyPrint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This API extracts slide titles and notes from `.pptx` files. It is built with **
 
 - **POST `/extract`** – Accepts a JSON payload with `file_url` and `file_name`. The `file_url` should point to a downloadable `.pptx` file while `file_name` will be returned in the response. Returns the slide titles and speaker notes for each slide.
 - **POST `/combine`** – Takes a `drive_id`, `folder_id` and `pptx_file_id` and produces an MP4 by downloading the PPTX and slide audio from SharePoint, creating slide images and stitching them together with 2 s crossfades. The resulting video is uploaded back to SharePoint and the URL returned.
+- **POST `/html-to-pdf`** and **POST `/html-to-pdf/async`** – Convert provided HTML into a PDF, synchronously or asynchronously.
 - Validation for supported file types and error handling for download/parse failures.
 - CORS enabled for testing purposes.
 - Suitable for running locally with `uvicorn` or in production with `gunicorn`.

--- a/extractor_api.py
+++ b/extractor_api.py
@@ -9,9 +9,10 @@ import re
 import asyncio
 
 import httpx
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, HttpUrl
+from weasyprint import HTML
 from pptx import Presentation
 
 from graph_utils import (
@@ -115,6 +116,10 @@ class CombineResponse(BaseModel):
     upload_url: str
 
 
+class HtmlToPdfRequest(BaseModel):
+    html: str
+
+
 def _extract_slides(presentation: Presentation) -> List[SlideData]:
     """Return slide metadata from a Presentation."""
     slides = []
@@ -136,6 +141,16 @@ def _parse_slide_number(path: Path) -> int:
         return int(match.group(1))
     logger.warning("Unexpected slide filename: %s", path.name)
     return 0
+
+
+def _html_to_pdf_bytes(html: str) -> bytes:
+    """Return PDF data generated from HTML."""
+    buf = io.BytesIO()
+    try:
+        HTML(string=html).write_pdf(target=buf)
+    except Exception as exc:  # pylint: disable=broad-except
+        raise ValueError("pdf generation failed") from exc
+    return buf.getvalue()
 
 
 def get_audio_duration(path: Path) -> float:
@@ -229,6 +244,28 @@ async def extract_notes(request: ExtractRequest):
         slide_count=len(slides_data),
         slides=slides_data,
     )
+
+
+@app.post("/html-to-pdf/async")
+async def html_to_pdf_async(request: HtmlToPdfRequest) -> Response:
+    """Generate a PDF from provided HTML text asynchronously."""
+    try:
+        pdf_bytes = await asyncio.to_thread(_html_to_pdf_bytes, request.html)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception("PDF generation failed")
+        raise HTTPException(status_code=500, detail="PDF generation failed") from exc
+    return Response(content=pdf_bytes, media_type="application/pdf")
+
+
+@app.post("/html-to-pdf")
+def html_to_pdf(request: HtmlToPdfRequest) -> Response:
+    """Generate a PDF from provided HTML text synchronously."""
+    try:
+        pdf_bytes = _html_to_pdf_bytes(request.html)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception("PDF generation failed")
+        raise HTTPException(status_code=500, detail="PDF generation failed") from exc
+    return Response(content=pdf_bytes, media_type="application/pdf")
 
 
 @app.post("/combine", response_model=CombineResponse)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-pptx
 requests
 gunicorn
 httpx
+weasyprint

--- a/tests/test_html_to_pdf.py
+++ b/tests/test_html_to_pdf.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import extractor_api
+
+client = TestClient(extractor_api.app)
+
+
+class DummyHTML:
+    def __init__(self, string):
+        self.string = string
+
+    def write_pdf(self, target):
+        target.write(b"%PDF-1.7")
+
+
+class FailingHTML(DummyHTML):
+    def write_pdf(self, target):
+        raise RuntimeError("fail")
+
+
+def test_html_to_pdf_sync_success():
+    with patch("extractor_api.HTML", DummyHTML):
+        res = client.post("/html-to-pdf", json={"html": "<h1>Hi</h1>"})
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "application/pdf"
+    assert res.content.startswith(b"%PDF")
+
+
+def test_html_to_pdf_async_success():
+    with patch("extractor_api.HTML", DummyHTML):
+        res = client.post("/html-to-pdf/async", json={"html": "<h1>Hi</h1>"})
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "application/pdf"
+    assert res.content.startswith(b"%PDF")
+
+
+def test_html_to_pdf_failure():
+    with patch("extractor_api.HTML", FailingHTML):
+        res = client.post("/html-to-pdf/async", json={"html": "<h1>Hi</h1>"})
+    assert res.status_code == 500
+    assert res.json()["detail"] == "PDF generation failed"


### PR DESCRIPTION
## Summary
- replace xhtml2pdf with WeasyPrint
- expose `/html-to-pdf` sync endpoint and `/html-to-pdf/async` async endpoint
- document new endpoints in README
- update tests for new implementation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi/httpx)*

------
https://chatgpt.com/codex/tasks/task_b_685438cb649c8322ba85fdffaf721e8f