### PR TITLE
Update HTML to PDF endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This API extracts slide titles and notes from `.pptx` files. It is built with **
 
 - **POST `/extract`** – Accepts a JSON payload with `file_url` and `file_name`. The `file_url` should point to a downloadable `.pptx` file while `file_name` will be returned in the response. Returns the slide titles and speaker notes for each slide.
 - **POST `/combine`** – Takes a `drive_id`, `folder_id` and `pptx_file_id` and produces an MP4 by downloading the PPTX and slide audio from SharePoint, creating slide images and stitching them together with 2 s crossfades. The resulting video is uploaded back to SharePoint and the URL returned.
-- **POST `/html-to-pdf`** and **POST `/html-to-pdf/async`** – Convert base64-encoded HTML into a PDF, synchronously or asynchronously.
+- **POST `/html-to-pdf`** and **POST `/html-to-pdf/async`** – Convert raw HTML into a PDF, synchronously or asynchronously.
 - Validation for supported file types and error handling for download/parse failures.
 - CORS enabled for testing purposes.
 - Suitable for running locally with `uvicorn` or in production with `gunicorn`.
@@ -105,7 +105,7 @@ curl -X POST http://localhost:8000/combine \
 ```bash
 curl -X POST http://localhost:8000/html-to-pdf \
   -H "Content-Type: text/plain" \
-  --data $(echo -n '<h1>Hello</h1>' | base64) \
+  --data '<h1>Hello</h1>' \
   -o output.pdf
 ```
 
@@ -114,6 +114,6 @@ curl -X POST http://localhost:8000/html-to-pdf \
 ```bash
 curl -X POST http://localhost:8000/html-to-pdf/async \
   -H "Content-Type: text/plain" \
-  --data $(echo -n '<h1>Hello</h1>' | base64) \
+  --data '<h1>Hello</h1>' \
   -o output.pdf
 ```

--- a/tests/test_html_to_pdf.py
+++ b/tests/test_html_to_pdf.py
@@ -1,5 +1,4 @@
 from unittest.mock import patch
-import base64
 
 from fastapi.testclient import TestClient
 
@@ -23,7 +22,7 @@ class FailingHTML(DummyHTML):
 
 def test_html_to_pdf_sync_success():
     with patch("extractor_api.HTML", DummyHTML):
-        payload = base64.b64encode(b"<h1>Hi</h1>")
+        payload = b"<h1>Hi</h1>"
         res = client.post("/html-to-pdf", data=payload)
     assert res.status_code == 200
     assert res.headers["content-type"] == "application/pdf"
@@ -32,7 +31,7 @@ def test_html_to_pdf_sync_success():
 
 def test_html_to_pdf_async_success():
     with patch("extractor_api.HTML", DummyHTML):
-        payload = base64.b64encode(b"<h1>Hi</h1>")
+        payload = b"<h1>Hi</h1>"
         res = client.post("/html-to-pdf/async", data=payload)
     assert res.status_code == 200
     assert res.headers["content-type"] == "application/pdf"
@@ -41,7 +40,7 @@ def test_html_to_pdf_async_success():
 
 def test_html_to_pdf_failure():
     with patch("extractor_api.HTML", FailingHTML):
-        payload = base64.b64encode(b"<h1>Hi</h1>")
+        payload = b"<h1>Hi</h1>"
         res = client.post("/html-to-pdf/async", data=payload)
     assert res.status_code == 500
     assert res.json()["detail"] == "PDF generation failed"


### PR DESCRIPTION
## Summary
- accept raw HTML bytes in `/html-to-pdf` endpoints
- update tests and documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6854cbb4911c83228eadad062af7db21