### PR TITLE
Fix PDF cropping by restoring landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This API extracts slide titles and notes from `.pptx` files. It is built with **
 
 - **POST `/extract`** – Accepts a JSON payload with `file_url` and `file_name`. The `file_url` should point to a downloadable `.pptx` file while `file_name` will be returned in the response. Returns the slide titles and speaker notes for each slide.
 - **POST `/combine`** – Takes a `drive_id`, `folder_id` and `pptx_file_id` and produces an MP4 by downloading the PPTX and slide audio from SharePoint, creating slide images and stitching them together with 2 s crossfades. The resulting video is uploaded back to SharePoint and the URL returned.
-- **POST `/html-to-pdf`** and **POST `/html-to-pdf/async`** – Convert raw HTML into a PDF, synchronously or asynchronously.
+- **POST `/html-to-pdf`** and **POST `/html-to-pdf/async`** – Convert raw HTML into a PDF, synchronously or asynchronously. Output pages are rendered in landscape orientation to avoid clipping wide content.
 - Validation for supported file types and error handling for download/parse failures.
 - CORS enabled for testing purposes.
 - Suitable for running locally with `uvicorn` or in production with `gunicorn`.

--- a/extractor_api.py
+++ b/extractor_api.py
@@ -12,7 +12,7 @@ import httpx
 from fastapi import FastAPI, HTTPException, Response, Body
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, HttpUrl
-from weasyprint import HTML
+from weasyprint import HTML, CSS
 from pptx import Presentation
 
 from graph_utils import (
@@ -152,8 +152,10 @@ def _html_to_pdf_bytes(html_bytes: bytes) -> bytes:
     buf = io.BytesIO()
     try:
         html = html_bytes.decode()
+        css = CSS(string="@page { size: A4 landscape; margin: 1cm }")
         HTML(string=html).write_pdf(
             target=buf,
+            stylesheets=[css],
             presentational_hints=True,
         )
     except UnicodeDecodeError as exc:


### PR DESCRIPTION
## Summary
- revert orientation removal so HTML to PDF uses A4 landscape again
- mention landscape output in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi/httpx)*

------
https://chatgpt.com/codex/tasks/task_b_6854d6d350b88322a603ef317f016648