### PR TITLE
Fix landscape PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This API extracts slide titles and notes from `.pptx` files. It is built with **
 
 - **POST `/extract`** – Accepts a JSON payload with `file_url` and `file_name`. The `file_url` should point to a downloadable `.pptx` file while `file_name` will be returned in the response. Returns the slide titles and speaker notes for each slide.
 - **POST `/combine`** – Takes a `drive_id`, `folder_id` and `pptx_file_id` and produces an MP4 by downloading the PPTX and slide audio from SharePoint, creating slide images and stitching them together with 2 s crossfades. The resulting video is uploaded back to SharePoint and the URL returned.
-- **POST `/html-to-pdf`** and **POST `/html-to-pdf/async`** – Convert raw HTML into a PDF, synchronously or asynchronously. Output pages are rendered in landscape orientation to avoid clipping wide content.
+- **POST `/html-to-pdf`** and **POST `/html-to-pdf/async`** – Convert raw HTML into a PDF, synchronously or asynchronously. Pages use a 29.7 cm × 21 cm (A4 landscape) canvas to avoid clipping wide content.
 - Validation for supported file types and error handling for download/parse failures.
 - CORS enabled for testing purposes.
 - Suitable for running locally with `uvicorn` or in production with `gunicorn`.

--- a/extractor_api.py
+++ b/extractor_api.py
@@ -152,7 +152,11 @@ def _html_to_pdf_bytes(html_bytes: bytes) -> bytes:
     buf = io.BytesIO()
     try:
         html = html_bytes.decode()
-        css = CSS(string="@page { size: A4 landscape; margin: 1cm }")
+        # Explicitly set the page size in landscape orientation to avoid
+        # clipping wide content. Some versions of WeasyPrint have trouble
+        # parsing ``A4 landscape`` so we specify the width and height
+        # directly.
+        css = CSS(string="@page { size: 29.7cm 21cm; margin: 1cm }")
         HTML(string=html).write_pdf(
             target=buf,
             stylesheets=[css],


### PR DESCRIPTION
## Summary
- clarify PDF page size in README
- specify explicit landscape dimensions to avoid cropping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6854d9a292f883228b0ed53f39bd49d4